### PR TITLE
Fix loadonly layout

### DIFF
--- a/src/exectrace.s
+++ b/src/exectrace.s
@@ -374,7 +374,7 @@ env_mes:      .dc.b LF,'ENV',    TAB,'= $00000000',LF,0
 buffer_mes:   .dc.b LF,'BUFFER', TAB,'= $00000000',0
 
 load_mes:     .dc.b LF,'LOAD',   TAB,'= $00000000',LF,0
-limit_mes:    .dc.b    'LIMIT',  TAB,'= $00000000',LF,0
+limit_mes:    .dc.b    'LIMIT',  TAB,'= $00000000',0
 
 address_mes:  .dc.b LF,'ADDRESS',TAB,'= $00000000',LF,0
 

--- a/src/exectrace.s
+++ b/src/exectrace.s
@@ -373,7 +373,7 @@ env_mes:      .dc.b LF,'ENV',    TAB,'= $00000000',LF,0
 
 buffer_mes:   .dc.b LF,'BUFFER', TAB,'= $00000000',0
 
-load_mes:     .dc.b    'LOAD',   TAB,'= $00000000',LF,0
+load_mes:     .dc.b LF,'LOAD',   TAB,'= $00000000',LF,0
 limit_mes:    .dc.b    'LIMIT',  TAB,'= $00000000',LF,0
 
 address_mes:  .dc.b LF,'ADDRESS',TAB,'= $00000000',LF,0


### PR DESCRIPTION
モード3(LOADONLY)の出力のレイアウトを修正しました。

修正前:

```
A>a.x b.z                                  
                                           
MD      = $0000(loadexec)                  
FILE    = $0007471e : a.x                  
CMDLINE = $000743ec : b.z                  
ENV     = $000752f0                        
RET     = $00076aa0                        
                                           
MD      = $0003(loadonly)                  
FILE    = $000743ed : b.zLOAD   = $00076ade
LIMIT   = $00076bde                        
                                           
ENV     = $00000007                        
RET     = $fffffff8                        
```

修正後:

```
A>a.x b.z                
                         
MD      = $0000(loadexec)
FILE    = $0007471e : a.x
CMDLINE = $000743ec : b.z
ENV     = $000752f0      
RET     = $00076aa0      
                         
MD      = $0003(loadonly)
FILE    = $000743ed : b.z
LOAD    = 00076ade0      
LIMIT   = $00076bde      
ENV     = $00000007      
RET     = $fffffff8      
```
